### PR TITLE
fix: replace std::env::current_dir with cargo env var CARGO_MANIFEST_DIR

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,7 +105,9 @@ pub fn setup() -> Result<(), E> {
     {
         return Ok(());
     }
-    let root = std::env::current_dir()?;
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
+    let root = PathBuf::from(manifest_dir);
+
     let cargo = root.join("Cargo.toml");
     if !cargo.exists() {
         return Err(E::FileNotFound(format!(


### PR DESCRIPTION
This PR addresses an issue where the resolution of the project root was not accurately finding the manifest file for member crates within a Cargo workspace. Previously, the implementation assumed that the current directory (`std::env::current_dir()`) was the project root. This assumption does not hold in Cargo workspaces.

The previous implementation:
```rust
let root = std::env::current_dir()?;
```

has been replaced with:
```rust
let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
let root = PathBuf::from(manifest_dir);
```

This change ensures that the `root` path is set to the directory containing the `Cargo.toml` of the current crate, as specified by the `CARGO_MANIFEST_DIR` environment variable set by Cargo. This approach guarantees correct file paths regardless of the current execution directory, specifically benefiting scenarios where the crate is part of a workspace.

### Benefits:
- Ensures correct manifest file detection for workspace member crates.
- Prevents errors related to incorrect path assumptions when crates are invoked from different directories within a workspace.

### Testing:
Current self tests still pass

### Notes:
- This change introduces a hard dependency on the `CARGO_MANIFEST_DIR` environment variable being set, which is a standard behavior when running through Cargo. please see: https://doc.rust-lang.org/cargo/reference/environment-variables.html
